### PR TITLE
[Feat] Issue-1063 Add Upstash-backed rate limiting

### DIFF
--- a/packages/app/__tests__/middlewares/rateLimiter.js
+++ b/packages/app/__tests__/middlewares/rateLimiter.js
@@ -1,0 +1,176 @@
+const {
+  RATE_LIMIT_POLICIES,
+  UpstashRateLimitStore,
+  createRateLimiter,
+} = require("../../middlewares/rateLimiter");
+const crypto = require("crypto");
+
+describe("rate limiter middleware", () => {
+  const originalEnv = process.env;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+    process.env.UPSTASH_REDIS_REST_URL = "https://example.upstash.io";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "token";
+    process.env.RATE_LIMIT_ENABLE_IN_TEST = "true";
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it("keeps the existing logo and base limits", () => {
+    expect(RATE_LIMIT_POLICIES.logo).toMatchObject({
+      windowMs: 60 * 1000,
+      limit: 100,
+    });
+    expect(RATE_LIMIT_POLICIES.base).toMatchObject({
+      windowMs: 60 * 1000,
+      limit: 60,
+    });
+    expect(RATE_LIMIT_POLICIES.auth).toMatchObject({
+      windowMs: 60 * 1000,
+      limit: 60,
+    });
+    expect(RATE_LIMIT_POLICIES.upload).toMatchObject({
+      windowMs: 60 * 1000,
+      limit: 60,
+    });
+  });
+
+  it("does not fall back to the express-rate-limit memory store", () => {
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+
+    const limiter = createRateLimiter(RATE_LIMIT_POLICIES.base);
+
+    expect(limiter.resetKey).toEqual(expect.any(Function));
+    expect(limiter._store.constructor.name).toBe("UpstashRateLimitStore");
+  });
+
+  it("uses Upstash store for rate limit counters", () => {
+    const limiter = createRateLimiter(RATE_LIMIT_POLICIES.base);
+
+    expect(limiter.resetKey).toEqual(expect.any(Function));
+    expect(limiter._store.constructor.name).toBe("UpstashRateLimitStore");
+  });
+
+  it("returns a consistent JSON response when the limit is exceeded", async () => {
+    const express = require("express");
+    const request = require("supertest");
+    const app = express();
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: jest
+          .fn()
+          .mockResolvedValue([{ result: 1 }, { result: 1 }, { result: 60 }]),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: jest
+          .fn()
+          .mockResolvedValue([{ result: 2 }, { result: 0 }, { result: 60 }]),
+      });
+
+    app.get(
+      "/limited",
+      createRateLimiter({
+        name: "test",
+        windowMs: 60 * 1000,
+        limit: 1,
+      }),
+      (_req, res) => res.status(200).json({ statusCode: 200 })
+    );
+
+    await request(app).get("/limited").expect(200);
+    const response = await request(app).get("/limited").expect(429);
+
+    expect(response.body).toEqual({
+      error: "Too Many Requests",
+      message: "Too many requests. Please try again later.",
+      statusCode: 429,
+    });
+    expect(response.headers["retry-after"]).toBeDefined();
+  });
+
+  it("uses client IPs for limiter keys", () => {
+    const limiter = createRateLimiter(RATE_LIMIT_POLICIES.logo);
+    const key = limiter._keyGenerator({
+      query: { API_KEY: "public-api-key" },
+      ip: "127.0.0.1",
+    });
+
+    const hash = crypto.createHash("sha256").update("127.0.0.1").digest("hex");
+    expect(key).toBe(`ip:${hash}`);
+  });
+
+  it("fails open when the Upstash store is unavailable", () => {
+    const limiter = createRateLimiter(RATE_LIMIT_POLICIES.base);
+
+    expect(limiter._passOnStoreError).toBe(true);
+  });
+
+  it("increments and expires Upstash keys in one fixed-window pipeline", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: jest
+          .fn()
+          .mockResolvedValue([{ result: 1 }, { result: 1 }, { result: 60 }]),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: jest.fn().mockResolvedValue([{ result: 1 }]),
+      });
+
+    const store = new UpstashRateLimitStore({ name: "base" });
+    store.init({ windowMs: 60 * 1000 });
+
+    const result = await store.increment("127.0.0.1");
+    await store.resetKey("127.0.0.1");
+
+    expect(result.totalHits).toBe(1);
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      1,
+      "https://example.upstash.io/pipeline",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify([
+          ["INCR", "openlogo:rate-limit:base:127.0.0.1"],
+          ["EXPIRE", "openlogo:rate-limit:base:127.0.0.1", 60, "NX"],
+          ["TTL", "openlogo:rate-limit:base:127.0.0.1"],
+        ]),
+      })
+    );
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      2,
+      "https://example.upstash.io/pipeline",
+      expect.objectContaining({
+        body: JSON.stringify([["DEL", "openlogo:rate-limit:base:127.0.0.1"]]),
+      })
+    );
+  });
+
+  it("throws a clear error when Upstash returns an invalid increment response", async () => {
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: jest.fn().mockResolvedValue([{ result: "NaN" }]),
+    });
+
+    const store = new UpstashRateLimitStore({ name: "base" });
+    store.init({ windowMs: 60 * 1000 });
+
+    await expect(store.increment("127.0.0.1")).rejects.toThrow(
+      "Invalid Upstash rate limit response"
+    );
+  });
+});

--- a/packages/app/__tests__/server.js
+++ b/packages/app/__tests__/server.js
@@ -1,0 +1,7 @@
+const app = require("../server");
+
+describe("server", () => {
+  it("trusts the Vercel proxy hop for client IP detection", () => {
+    expect(app.get("trust proxy")).toBe(1);
+  });
+});

--- a/packages/app/__tests__/utils/envSchema.js
+++ b/packages/app/__tests__/utils/envSchema.js
@@ -1,0 +1,55 @@
+const { validateEnv } = require("../../utils/envSchema");
+
+const validEnv = {
+  ACCESS_KEY: "access-key",
+  ADMINSEMAILS: "admin@example.com",
+  BUCKET_KEY: "logos",
+  BUCKET_NAME: "bucket",
+  BUCKET_REGION: "us-east-1",
+  CLIENT_PROXY_URL: "https://proxy.example.com",
+  CLIENT_URL: "https://app.example.com",
+  CLOUD_FRONT_KEYPAIR_ID: "ABC123",
+  CLOUD_FRONT_PRIVATE_KEY: "private-key",
+  CRYPTO_KEY:
+    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  DISTRIBUTION_DOMAIN: "https://abc.cloudfront.net",
+  MONGO_URL: "mongodb://localhost:27017/openlogo",
+  NODE_ENV: "prod",
+  PORT: "3000",
+  SECRET_ACCESS_KEY: "secret-key",
+  UPSTASH_REDIS_REST_TOKEN: "token",
+  UPSTASH_REDIS_REST_URL: "https://example.upstash.io",
+};
+
+describe("env schema", () => {
+  it("accepts complete Upstash rate limit configuration", () => {
+    const { error } = validateEnv({
+      ...validEnv,
+      UPSTASH_REDIS_REST_URL: "https://example.upstash.io",
+      UPSTASH_REDIS_REST_TOKEN: "token",
+      RATE_LIMIT_REDIS_PREFIX: "openlogo:test",
+    });
+
+    expect(error).toBeUndefined();
+  });
+
+  it("rejects partial Upstash rate limit configuration", () => {
+    const { error } = validateEnv({
+      ...validEnv,
+      UPSTASH_REDIS_REST_URL: "https://example.upstash.io",
+      UPSTASH_REDIS_REST_TOKEN: undefined,
+    });
+
+    expect(error).toBeDefined();
+  });
+
+  it("rejects missing Upstash rate limit configuration", () => {
+    const { error } = validateEnv({
+      ...validEnv,
+      UPSTASH_REDIS_REST_URL: undefined,
+      UPSTASH_REDIS_REST_TOKEN: undefined,
+    });
+
+    expect(error).toBeDefined();
+  });
+});

--- a/packages/app/controllers/auth.js
+++ b/packages/app/controllers/auth.js
@@ -58,7 +58,7 @@ async function signupController(req, res, next) {
       const tenureDays = 30;
       const expiry = dayjs(user.deleted_at).add(tenureDays, "day");
       if (expiry.isAfter(dayjs())) {
-        const daysLeft = expiry.diff(dayjs(), "day") + 1;
+        const daysLeft = Math.ceil(expiry.diff(dayjs(), "day", true));
         return res.status(400).json({
           message: `Account exists. You may re-register after ${daysLeft} days.`,
           error: STATUS_CODES[400],

--- a/packages/app/middlewares/rateLimiter.js
+++ b/packages/app/middlewares/rateLimiter.js
@@ -1,17 +1,169 @@
+const { STATUS_CODES } = require("node:http");
+const crypto = require("node:crypto");
 const rateLimit = require("express-rate-limit");
+const { Messages } = require("../utils/constants");
 
-const logoLimiter = rateLimit({
-  windowMs: 60 * 1000, // 1 minute
-  limit: 100,
-  standardHeaders: "draft-8", //  eigth draft of the IETF rate limit header specification
-  legacyHeaders: false,
-});
+const RATE_LIMIT_POLICIES = {
+  logo: {
+    name: "logo",
+    windowMs: 60 * 1000,
+    limit: 100,
+  },
+  base: {
+    name: "base",
+    windowMs: 60 * 1000,
+    limit: 60,
+  },
+  auth: {
+    name: "auth",
+    windowMs: 60 * 1000,
+    limit: 60,
+  },
+  upload: {
+    name: "upload",
+    windowMs: 60 * 1000,
+    limit: 60,
+  },
+};
 
-const baseLimiter = rateLimit({
-  windowMs: 60 * 1000, // 1 minute
-  limit: 60,
-  standardHeaders: "draft-8", //  eigth draft of the IETF rate limit header specification
-  legacyHeaders: false,
-});
+class UpstashRateLimitStore {
+  constructor({
+    prefix = process.env.RATE_LIMIT_REDIS_PREFIX || "openlogo:rate-limit",
+    name,
+  }) {
+    this.prefix = prefix;
+    this.name = name;
+  }
 
-module.exports = { logoLimiter, baseLimiter };
+  init(options) {
+    this.windowMs = options.windowMs;
+  }
+
+  async increment(key) {
+    const redisKey = this.getRedisKey(key);
+    const ttlSeconds = Math.ceil(this.windowMs / 1000);
+    const now = Date.now();
+    const [hitsResult, , ttlResult] = await this.request("/pipeline", [
+      ["INCR", redisKey],
+      ["EXPIRE", redisKey, ttlSeconds, "NX"],
+      ["TTL", redisKey],
+    ]);
+
+    if (!hitsResult || !ttlResult) {
+      throw new Error("Invalid Upstash rate limit response");
+    }
+
+    const totalHits = Number(hitsResult.result);
+    let ttl = Number(ttlResult.result);
+
+    if (
+      !Number.isInteger(totalHits) ||
+      totalHits < 1 ||
+      !Number.isFinite(ttl)
+    ) {
+      throw new Error("Invalid Upstash rate limit response");
+    }
+
+    if (ttl < 0) {
+      ttl = ttlSeconds;
+    }
+
+    return {
+      totalHits,
+      resetTime: new Date(now + ttl * 1000),
+    };
+  }
+
+  decrement() {
+    return undefined;
+  }
+
+  async resetKey(key) {
+    await this.request("/pipeline", [["DEL", this.getRedisKey(key)]]);
+  }
+
+  getRedisKey(key) {
+    return `${this.prefix}:${this.name}:${key}`;
+  }
+
+  async request(path, body) {
+    const response = await fetch(
+      `${process.env.UPSTASH_REDIS_REST_URL}${path}`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${process.env.UPSTASH_REDIS_REST_TOKEN}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`Upstash rate limit request failed: ${response.status}`);
+    }
+
+    return response.json();
+  }
+}
+
+const createStore = (policy) => {
+  return new UpstashRateLimitStore({ name: policy.name });
+};
+
+const hashIdentifier = (value) =>
+  crypto.createHash("sha256").update(String(value)).digest("hex");
+
+const getClientKey = (req) => {
+  const ip = req.ip || req.socket?.remoteAddress || "unknown";
+  return `ip:${hashIdentifier(ip)}`;
+};
+
+const rateLimitHandler = (_req, res) =>
+  res.status(429).json({
+    error: STATUS_CODES[429],
+    message: Messages.TOO_MANY_REQUESTS,
+    statusCode: 429,
+  });
+
+const shouldSkipRateLimit = (req) =>
+  req.method === "OPTIONS" ||
+  (process.env.NODE_ENV === "test" &&
+    process.env.RATE_LIMIT_ENABLE_IN_TEST !== "true");
+
+const createRateLimiter = (policy) => {
+  const store = createStore(policy);
+  const passOnStoreError = true;
+  const limiter = rateLimit({
+    windowMs: policy.windowMs,
+    limit: policy.limit,
+    standardHeaders: "draft-8",
+    legacyHeaders: false,
+    store,
+    keyGenerator: getClientKey,
+    skip: shouldSkipRateLimit,
+    handler: rateLimitHandler,
+    passOnStoreError,
+  });
+
+  limiter._store = store;
+  limiter._keyGenerator = getClientKey;
+  limiter._passOnStoreError = passOnStoreError;
+  return limiter;
+};
+
+const logoLimiter = createRateLimiter(RATE_LIMIT_POLICIES.logo);
+const baseLimiter = createRateLimiter(RATE_LIMIT_POLICIES.base);
+const authLimiter = createRateLimiter(RATE_LIMIT_POLICIES.auth);
+const uploadLimiter = createRateLimiter(RATE_LIMIT_POLICIES.upload);
+
+module.exports = {
+  RATE_LIMIT_POLICIES,
+  UpstashRateLimitStore,
+  createRateLimiter,
+  getClientKey,
+  logoLimiter,
+  baseLimiter,
+  authLimiter,
+  uploadLimiter,
+};

--- a/packages/app/routes/catalog.js
+++ b/packages/app/routes/catalog.js
@@ -8,6 +8,7 @@ const {
   addCatalogController,
   getAnalyticsController,
 } = require("../controllers/catalog");
+const { uploadLimiter } = require("../middlewares/rateLimiter");
 const { UserType } = require("../utils/constants");
 
 router.put(
@@ -35,6 +36,7 @@ router.post(
 
 router.post(
   "/signed-url",
+  uploadLimiter,
   authMiddleware({ roles: [UserType.ADMIN, UserType.OPERATOR] }),
   getPreSignedController
 );

--- a/packages/app/routes/index.js
+++ b/packages/app/routes/index.js
@@ -7,7 +7,11 @@ const businessRouter = require("./logo");
 const adminRouter = require("./catalog");
 const requestRouter = require("./request");
 const logoRequestLogsRouter = require("./logoRequestLogs");
-const { logoLimiter, baseLimiter } = require("../middlewares/rateLimiter");
+const {
+  authLimiter,
+  baseLimiter,
+  logoLimiter,
+} = require("../middlewares/rateLimiter");
 const createLogoRequestRouter = require("./createLogoRequest");
 const rewardsRouter = require("./rewards");
 const adminRewardsRouter = require("./admin/rewards");
@@ -33,7 +37,7 @@ const privateRouteCORS = {
 
 router.use("/messages", baseLimiter, cors(privateRouteCORS), operatorRouter);
 router.use("/user", baseLimiter, cors(privateRouteCORS), userRouter);
-router.use("/auth", baseLimiter, cors(privateRouteCORS), authRouter);
+router.use("/auth", authLimiter, cors(privateRouteCORS), authRouter);
 router.use("/logo", logoLimiter, cors(privateRouteCORS), businessRouter);
 router.use("/catalog", baseLimiter, cors(privateRouteCORS), adminRouter);
 router.use("/requests", baseLimiter, cors(privateRouteCORS), requestRouter);

--- a/packages/app/server.js
+++ b/packages/app/server.js
@@ -27,6 +27,7 @@ if (process.env.NODE_ENV !== "test") {
 }
 
 const app = express();
+app.set("trust proxy", 1);
 app.use(cookieParser());
 app.disable("x-powered-by");
 app.use(express.json());

--- a/packages/app/utils/envSchema.js
+++ b/packages/app/utils/envSchema.js
@@ -27,6 +27,9 @@ const EnvSchema = Joi.object()
       .required(),
     EMAIL_SERVICE_URL: Joi.string().optional(),
     EMAIL_SERVICE_AUTH_TOKEN: Joi.string().optional(),
+    UPSTASH_REDIS_REST_URL: Joi.string().uri().required(),
+    UPSTASH_REDIS_REST_TOKEN: Joi.string().required(),
+    RATE_LIMIT_REDIS_PREFIX: Joi.string().optional(),
     ADMINSEMAILS: Joi.string().required(),
     BUCKET_KEY: Joi.string().required(),
     CRYPTO_KEY: Joi.string().length(64).hex().required().messages({
@@ -35,6 +38,7 @@ const EnvSchema = Joi.object()
       "string.hex": "Crypto key must be a valid hex string",
     }),
   })
+  .and("UPSTASH_REDIS_REST_URL", "UPSTASH_REDIS_REST_TOKEN")
   .unknown(true);
 
 /**


### PR DESCRIPTION
## Description
Closes #1063

This PR improves rate limiting for the Vercel/serverless deployment by replacing in-memory rate limit counters with Upstash Redis-backed IP rate limiting.

Changes included:
- Centralized reusable rate limit policies.
- Added Upstash-backed store for `express-rate-limit`.
- Kept existing limits:
  - `/api/logo/*` → 100 req/min
  - other main API routes → 60 req/min
- Added dedicated auth and upload/signed-url limiters.
- Added consistent JSON `429` responses.
- Added proxy trust config for Vercel client IP handling.
- Added env validation for required Upstash config.
- Added tests for rate limit behavior and env validation.

Closes #1063 

## What type of PR is this? (Check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📄 Documentation Update
- [x] 👨‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🛠️ CI/CD

## Screenshots (if applicable)
Not applicable.

## Checklist
- [x] I have performed a self-review of my code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [x] I have added tests that prove my fix is effective or that my feature works  
- [x] New and existing unit tests pass locally with my changes