### PR TITLE
[Fix] Issue-1089 Pin pnpm version and preserve corepack cache in Dockerfiles

### DIFF
--- a/packages/app/Dockerfile
+++ b/packages/app/Dockerfile
@@ -5,9 +5,9 @@ WORKDIR /app
 COPY package.json ./
 
 RUN corepack enable && \
-    corepack prepare pnpm@latest --activate && \
+    corepack prepare pnpm@10 --activate && \
     pnpm install --prod && \
-    rm -rf ~/.pnpm-store /root/.cache /root/.local
+    rm -rf ~/.pnpm-store /root/.local
 
 COPY . .
 

--- a/packages/ui/Dockerfile
+++ b/packages/ui/Dockerfile
@@ -2,7 +2,7 @@ FROM node:20-alpine AS builder
 
 WORKDIR /app
 
-RUN npm install -g pnpm
+RUN npm install -g pnpm@10
 
 COPY package.json ./
 


### PR DESCRIPTION
## Description
Fixes #1089. 
- `docker-compose up --build` currently fails/crash-loops because both Dockerfiles resolve pnpm to an unpinned "latest" version, which is incompatible with the `node:20-alpine` base image.
- After above fix, `packages/app/Dockerfile`'s cache cleanup step was removing the pinned pnpm version needed at container runtime.

## What type of PR is this? (Check all applicable)
- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📄 Documentation Update
- [ ] 👨‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🛠️ CI/CD

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes. -->

## Checklist
- [x] I have performed a self-review of my code  
- [ ] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have added tests that prove my fix is effective or that my feature works  
- [ ] New and existing unit tests pass locally with my changes