### PR TITLE
[Feat] Issue-1095 Display logo file extension in search results

### DIFF
--- a/packages/app/__tests__/services/images.js
+++ b/packages/app/__tests__/services/images.js
@@ -90,14 +90,28 @@ describe("Image Service", () => {
       .mockResolvedValue("signed-url");
 
     const mockCompanies = [
-      { company_name: MOCK_IMAGES[0].company_name },
-      { company_name: MOCK_IMAGES[1].company_name },
+      {
+        company_name: MOCK_IMAGES[0].company_name,
+        extension: MOCK_IMAGES[0].extension,
+      },
+      {
+        company_name: MOCK_IMAGES[1].company_name,
+        extension: MOCK_IMAGES[1].extension,
+      },
     ];
     const result = await imageService.getDataList(mockCompanies);
 
     expect(result).toEqual([
-      { companyName: "GOOGLE", image: "signed-url" },
-      { companyName: "MICROSOFT", image: "signed-url" },
+      {
+        companyName: "GOOGLE",
+        image: "signed-url",
+        extension: MOCK_IMAGES[0].extension,
+      },
+      {
+        companyName: "MICROSOFT",
+        image: "signed-url",
+        extension: MOCK_IMAGES[1].extension,
+      },
     ]);
   });
 

--- a/packages/app/services/images.js
+++ b/packages/app/services/images.js
@@ -83,6 +83,7 @@ class ImageServices {
         dataList.push({
           companyName: company.company_name.split(".")[0],
           image: signedUrl,
+          extension: company.extension,
         });
       }
     }

--- a/packages/ui/__tests__/components/Demo.test.jsx
+++ b/packages/ui/__tests__/components/Demo.test.jsx
@@ -72,10 +72,10 @@ describe("Demo Component", () => {
       makeRequest: vi.fn(),
       data: {
         data: [
-          { companyName: "Aalto", image: "aalto-logo.svg" },
-          { companyName: "Aareon", image: "aareon-logo.svg" },
-          { companyName: "Aavid", image: "aavid-logo.svg" },
-          { companyName: "Aastra", image: "aastra-logo.svg" },
+          { companyName: "Aalto", image: "aalto-logo.svg", extension: "svg" },
+          { companyName: "Aareon", image: "aareon-logo.svg", extension: "png" },
+          { companyName: "Aavid", image: "aavid-logo.svg", extension: "svg" },
+          { companyName: "Aastra", image: "aastra-logo.svg", extension: "svg" },
         ],
       },
       loading: false,
@@ -98,7 +98,9 @@ describe("Demo Component", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Aalto")).toBeInTheDocument();
+      expect(screen.getAllByText("SVG")).toHaveLength(2);
       expect(screen.getByText("Aareon")).toBeInTheDocument();
+      expect(screen.getByText("PNG")).toBeInTheDocument();
       expect(screen.getByText("Aavid")).toBeInTheDocument();
       expect(screen.queryByText("Aastra")).not.toBeInTheDocument();
     });

--- a/packages/ui/src/components/demo/Demo.jsx
+++ b/packages/ui/src/components/demo/Demo.jsx
@@ -158,9 +158,18 @@ const Demo = ({ openAuthModal }) => {
                           >
                             <div className={styles.resultHeader}>
                               <img src={company.image} alt="logo" />
-                              <h3>
-                                {firstLetterCapitalString(company.companyName)}
-                              </h3>
+                              <div className={styles.brandInfo}>
+                                <h3>
+                                  {firstLetterCapitalString(
+                                    company.companyName
+                                  )}
+                                </h3>
+                                {company.extension && (
+                                  <span className={styles.formatBadge}>
+                                    {company.extension.toUpperCase()}
+                                  </span>
+                                )}
+                              </div>
                               <button
                                 type="button"
                                 onClick={() => handleCopyLink(company)}

--- a/packages/ui/src/components/demo/Demo.module.css
+++ b/packages/ui/src/components/demo/Demo.module.css
@@ -363,11 +363,32 @@
   background-color: var(--white-fixed);
 }
 
-.resultHeader h3 {
+.brandInfo {
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.2rem;
+}
+
+.resultHeader h3 {
   font-size: 1.2rem;
   font-weight: 600;
   color: var(--black);
+  margin: 0;
+}
+
+.formatBadge {
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: var(--description);
+  background: var(--grey);
+  border: 1px solid var(--border-color);
+  padding: 0.15rem 0.45rem;
+  border-radius: 4px;
+  text-transform: uppercase;
+  line-height: 1;
+  display: inline-block;
 }
 
 .copyBtn {


### PR DESCRIPTION
## Description

Closes #1095

This PR adds support for displaying the logo file extension in search results.

### Changes
- Adds the `extension` field to the backend search response.
- Displays the logo format (e.g. PNG, SVG) as a badge in the search result card.
- Adds/updates tests for the extension field and UI display.

## What type of PR is this? (Check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📄 Documentation Update
- [ ] 👨‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🛠️ CI/CD

## Screenshots (if applicable)

Before:

<img width="1565" height="752" alt="image" src="https://github.com/user-attachments/assets/a470c77f-c2c9-4b27-810e-0aa544a253b4" />


After:

<img width="1672" height="858" alt="image" src="https://github.com/user-attachments/assets/d7b55ec4-8e65-4d8c-83ca-2f553c88839e" />

<img width="731" height="421" alt="image" src="https://github.com/user-attachments/assets/2eceb074-2da1-4dd9-97c2-359e7956facf" />


## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
