### PR TITLE
[Fix] Issue-1094 Redirect /api/logo to signed CloudFront URL

### DIFF
--- a/packages/app/__tests__/controllers/logo/get-logo.js
+++ b/packages/app/__tests__/controllers/logo/get-logo.js
@@ -149,7 +149,7 @@ describe("getLogoController", () => {
     });
   });
 
-  it("200-images returned", async () => {
+  it("302 redirect returned", async () => {
     mockRepeatedService(mockSubscription[0]);
 
     jest
@@ -162,11 +162,8 @@ describe("getLogoController", () => {
       .spyOn(UserService.prototype, "logLogoRequestEntry")
       .mockResolvedValue({});
     const response = await request(app).get(apiUrl).query(baseQuery);
-    expect(response.status).toBe(200);
-    expect(response.body).toEqual({
-      statusCode: 200,
-      data: MOCK_IMAGE_URL_RESPONSE,
-    });
+    expect(response.status).toBe(302);
+    expect(response.headers.location).toBe(MOCK_IMAGE_URL_RESPONSE);
   });
 });
 
@@ -235,11 +232,8 @@ describe("getLogoController - Operations Order Test", () => {
 
     const response = await request(app).get(apiUrl).query(baseQuery);
 
-    expect(response.status).toBe(200);
-    expect(response.body).toEqual({
-      statusCode: 200,
-      data: MOCK_IMAGE_URL_RESPONSE,
-    });
+    expect(response.status).toBe(302);
+    expect(response.headers.location).toBe(MOCK_IMAGE_URL_RESPONSE);
 
     expect(operationsOrder).toEqual([
       "image_fetched",

--- a/packages/app/controllers/logo.js
+++ b/packages/app/controllers/logo.js
@@ -86,10 +86,7 @@ async function getLogoController(req, res, next) {
     subscriptionService.incrementUsageCount(userSubscription).catch((err) => {
       console.error("Failed to increment usage count:", err.message);
     });
-    return res.status(200).json({
-      statusCode: 200,
-      data: imageUrl,
-    });
+    return res.redirect(302, imageUrl);
   } catch (err) {
     next(err);
   }


### PR DESCRIPTION
## Description

Closes #1094 

Updated the `/api/logo` endpoint to redirect successful logo requests directly to the generated signed CloudFront url instead of returning the url inside a JSON response.

This allows the API endpoint to be used directly as an image source in HTML, Markdown, email templates, and other clients that expect an image resource.

The existing authentication, validation, rate limiting, logo lookup, and error handling behavior remains unchanged.

## What type of PR is this? (Check all applicable)

* [x] 🍕 Feature
* [ ] 🐛 Bug Fix
* [ ] 📄 Documentation Update
* [ ] 👨‍💻 Code Refactor
* [ ] 🔥 Performance Improvements
* [x] ✅ Test
* [ ] 🛠️ CI/CD

## Screenshots (if applicable)
<img width="1907" height="869" alt="image" src="https://github.com/user-attachments/assets/df9b3782-fddd-4e76-9dca-ad7f18679782" />

## Checklist

* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [x] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
