### PR TITLE
fix(ui): update delete API key confirmation modal

### DIFF
--- a/packages/ui/__tests__/components/ConfirmationModal.test.jsx
+++ b/packages/ui/__tests__/components/ConfirmationModal.test.jsx
@@ -16,6 +16,14 @@ const defaultProps = {
 };
 
 describe("ConfirmationModal Component", () => {
+  it("renders the API-key layout only when the API-key variant is selected", () => {
+    render(<ConfirmationModal {...defaultProps} variant="api-key" />);
+
+    expect(
+      screen.getByTestId("api-key-confirmation-layout")
+    ).toBeInTheDocument();
+  });
+
   it("renders heading, description and buttons", () => {
     render(<ConfirmationModal {...defaultProps} />);
 

--- a/packages/ui/src/components/confirm/ConfirmationModal.jsx
+++ b/packages/ui/src/components/confirm/ConfirmationModal.jsx
@@ -3,6 +3,7 @@ import Button from "../common/button/Button.jsx";
 import styles from "./ConfirmationModal.module.css";
 import PropTypes from "prop-types";
 import { CONFIRMATION_MODAL } from "../../utils/Constants.js";
+import { AlertTriangle } from "lucide-react";
 
 function ConfirmationModal({
   isOpen,
@@ -15,36 +16,83 @@ function ConfirmationModal({
   customHeading,
   customDescription,
   customWidth,
+  variant = "default",
 }) {
   const handleSubmit = (e) => {
     e.preventDefault();
     onConfirm();
   };
 
+  const isApiKeyVariant = variant === "api-key";
+
   return (
-    <Modal onClose={onClose} isOpen={isOpen} customWidth={customWidth}>
-      <form onSubmit={handleSubmit}>
-        <h2 className={styles["confirm-modal-heading"]}>
-          {customHeading || CONFIRMATION_MODAL.heading}
-        </h2>
-        <div className={styles["confirm-modal-description"]}>
-          {customDescription || CONFIRMATION_MODAL.description}
+    <Modal
+      onClose={onClose}
+      isOpen={isOpen}
+      customWidth={customWidth}
+      customClass={isApiKeyVariant ? styles["confirm-modal"] : undefined}
+    >
+      {isApiKeyVariant ? (
+        <div
+          className={styles["confirm-wrapper"]}
+          data-testid="api-key-confirmation-layout"
+        >
+          <div className={styles.sidebar}>
+            <div className={styles["sidebar-content"]}>
+              <AlertTriangle
+                className={styles["sidebar-icon"]}
+                aria-hidden="true"
+              />
+              <h2 className={styles["confirm-modal-heading"]}>
+                {customHeading || CONFIRMATION_MODAL.heading}
+              </h2>
+            </div>
+          </div>
+
+          <form onSubmit={handleSubmit} className={styles["form-section"]}>
+            <div className={styles["confirm-modal-description"]}>
+              {customDescription || CONFIRMATION_MODAL.description}
+            </div>
+            {children}
+            <div className={styles["confirm-modal-button-wrapper"]}>
+              <Button type="button" variant="secondary" onClick={onClose}>
+                {CONFIRMATION_MODAL.secondaryButtonText}
+              </Button>
+              <Button
+                variant="danger"
+                type="submit"
+                disabled={isConfirmDisabled}
+                isLoading={isConfirmLoading}
+              >
+                {confirmButtonContent || CONFIRMATION_MODAL.primaryButtonText}
+              </Button>
+            </div>
+          </form>
         </div>
-        {children}
-        <div className={styles["confirm-modal-button-wrapper"]}>
-          <Button type="button" variant="secondary" onClick={onClose}>
-            {CONFIRMATION_MODAL.secondaryButtonText}
-          </Button>
-          <Button
-            variant="danger"
-            type="submit"
-            disabled={isConfirmDisabled}
-            isLoading={isConfirmLoading}
-          >
-            {confirmButtonContent || CONFIRMATION_MODAL.primaryButtonText}
-          </Button>
-        </div>
-      </form>
+      ) : (
+        <form onSubmit={handleSubmit}>
+          <h2 className={styles["confirm-modal-heading"]}>
+            {customHeading || CONFIRMATION_MODAL.heading}
+          </h2>
+          <div className={styles["confirm-modal-description"]}>
+            {customDescription || CONFIRMATION_MODAL.description}
+          </div>
+          {children}
+          <div className={styles["confirm-modal-button-wrapper"]}>
+            <Button type="button" variant="secondary" onClick={onClose}>
+              {CONFIRMATION_MODAL.secondaryButtonText}
+            </Button>
+            <Button
+              variant="danger"
+              type="submit"
+              disabled={isConfirmDisabled}
+              isLoading={isConfirmLoading}
+            >
+              {confirmButtonContent || CONFIRMATION_MODAL.primaryButtonText}
+            </Button>
+          </div>
+        </form>
+      )}
     </Modal>
   );
 }
@@ -60,6 +108,7 @@ ConfirmationModal.propTypes = {
   customHeading: PropTypes.node,
   customDescription: PropTypes.node,
   customWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  variant: PropTypes.oneOf(["default", "api-key"]),
 };
 
 export default ConfirmationModal;

--- a/packages/ui/src/components/confirm/ConfirmationModal.module.css
+++ b/packages/ui/src/components/confirm/ConfirmationModal.module.css
@@ -20,3 +20,97 @@
   gap: 0.75rem;
   margin-top: 1rem;
 }
+
+/* API-key delete layout */
+.confirm-modal {
+  width: 660px;
+  max-width: 95vw;
+  padding: 0;
+  overflow-y: auto;
+}
+
+.confirm-wrapper {
+  display: flex;
+  min-height: 350px;
+}
+
+.sidebar {
+  flex: 0 0 40%;
+  padding: 2rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  border-right: 1px solid var(--border-color);
+  border-radius: 12px 0 0 12px;
+  background-color: var(--white);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40'%3E%3Cpath d='M0 0h40v40H0z' fill='none'/%3E%3Cpath d='M40 0v40M0 0h40' stroke='%23cbd5e1' stroke-width='1'/%3E%3C/svg%3E");
+  background-size: 40px 40px;
+}
+
+[data-theme="dark"] .sidebar {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40'%3E%3Cpath d='M0 0h40v40H0z' fill='none'/%3E%3Cpath d='M40 0v40M0 0h40' stroke='%232d3748' stroke-width='0.5'/%3E%3C/svg%3E");
+}
+
+.sidebar-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.sidebar-icon {
+  color: var(--primary);
+  width: 36px;
+  height: 36px;
+}
+
+.sidebar .confirm-modal-heading {
+  font-size: 1.75rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.form-section {
+  flex: 1;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.25rem;
+}
+
+.form-section .confirm-modal-button-wrapper {
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.form-section .confirm-modal-button-wrapper button {
+  flex: 1;
+}
+
+@media (max-width: 600px) {
+  .confirm-modal {
+    width: 95vw;
+  }
+
+  .confirm-wrapper {
+    flex-direction: column;
+    min-height: auto;
+  }
+
+  .sidebar {
+    flex: none;
+    border-right: none;
+    border-bottom: 1px solid var(--border-color);
+    border-radius: 12px 12px 0 0;
+    padding: 1.5rem;
+  }
+
+  .confirm-modal .confirm-modal-heading {
+    font-size: 1.35rem;
+  }
+
+  .form-section {
+    padding: 1.5rem 1.5rem 2rem 1.5rem;
+  }
+}

--- a/packages/ui/src/page/dashboard/Dashboard.jsx
+++ b/packages/ui/src/page/dashboard/Dashboard.jsx
@@ -379,6 +379,7 @@ function Dashboard() {
             isOpen={showModal}
             onClose={handleModalClose}
             onConfirm={handleDeleteKey}
+            variant="api-key"
             isConfirmDisabled={confirmKeyName !== selectedKey?.key_description}
             isConfirmLoading={isDeleting}
             confirmButtonContent={BUTTON_TEXT.delete}


### PR DESCRIPTION
## Description

Closes #1099

Updated the delete API key confirmation modal to match the approved design.

The new layout is opt-in and enabled only for API-key deletion. Existing account deletion and admin milestone modals keep their current layout and behavior.

Preserved:

- API-key name confirmation
- Disabled confirm button
- Loading state
- Cancel behavior
- Delete request

## What type of PR is this? (Check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📄 Documentation Update
- [ ] 👨‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🛠️ CI/CD



## Screenshots (if applicable)

https://github.com/user-attachments/assets/dbf5cae7-5547-4f66-90ac-773cf8f0904e

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing focused unit tests pass locally with my changes

Note: The repository-wide Prettier check reports 15 unrelated formatting issues outside this PR.
